### PR TITLE
Only copy external source files if external files are provided

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1350,10 +1350,17 @@ Check to make sure all required properties are specified. This includes properti
           <fileset dir="${generated.java}"/>
           <fileset dir="${generated.config.java}"/>
         </copy>
-        <copy todir="${temp-source}" overwrite="true">
-          <!--External files may overwrite files in the JikesRVM-->
-          <fileset dir="${external.java}"/>
-        </copy>
+        <if>
+          <conditions>
+            <not><equals arg1="${external.java}" arg2=""/></not>
+          </conditions>
+          <sequential>
+            <copy todir="${temp-source}" overwrite="true">
+              <!--External files may overwrite files in the JikesRVM-->
+              <fileset dir="${external.java}"/>
+            </copy>
+          </sequential>
+        </if>
         <javac destdir="${build.classes}"
                debug="true"
                fork="true"
@@ -1401,10 +1408,17 @@ Check to make sure all required properties are specified. This includes properti
           <fileset dir="${generated.java}"/>
           <fileset dir="${generated.config.java}"/>
         </copy>
-        <copy todir="${temp-source}" overwrite="true">
-          <!--External files may overwrite files in the JikesRVM-->
-          <fileset dir="${external.java}"/>
-        </copy>
+        <if>
+          <conditions>
+            <not><equals arg1="${external.java}" arg2=""/></not>
+          </conditions>
+          <sequential>
+            <copy todir="${temp-source}" overwrite="true">
+              <!--External files may overwrite files in the JikesRVM-->
+              <fileset dir="${external.java}"/>
+            </copy>
+          </sequential>
+        </if>
         <javac destdir="${build.classes}"
                debug="true"
                fork="true"


### PR DESCRIPTION
`${external.java}` could be empty `""` if no extern source is provided. The `copy` gets executed with an empty `fileset`. This does not seem to prevent build but I am not sure if there would be any strange behavior. This PR adds a condition so if `${external.java}` is empty, the `copy` will be skipped.