### PR TITLE
Clean up add ref candidates API. Add sysGetBooleanOption().

### DIFF
--- a/MMTk/src/org/mmtk/utility/options/NoReferenceTypes.java
+++ b/MMTk/src/org/mmtk/utility/options/NoReferenceTypes.java
@@ -22,6 +22,6 @@ public final class NoReferenceTypes extends org.vmutil.options.BooleanOption {
   public NoReferenceTypes() {
     super(Options.set, "No Reference Types",
           "Should reference type processing be disabled?",
-          true);
+          false);
   }
 }

--- a/rvm/src/org/jikesrvm/mm/mminterface/MemoryManager.java
+++ b/rvm/src/org/jikesrvm/mm/mminterface/MemoryManager.java
@@ -220,7 +220,7 @@ public final class MemoryManager {
       VM.sysFail("postBoot() unimplemented");
     } else {
       Selected.Plan.get().processOptions();
-      if (Options.noReferenceTypes.getValue()) {
+      if (Options.noReferenceTypes.getValue() || (VM.BuildWithRustMMTk && sysCall.sysGetBooleanOption(Options.noReferenceTypes.getKey().getBytes()))) {
         RVMType.JavaLangRefReferenceReferenceField.makeTraced();
       }
 

--- a/rvm/src/org/jikesrvm/mm/mminterface/MemoryManager.java
+++ b/rvm/src/org/jikesrvm/mm/mminterface/MemoryManager.java
@@ -1176,8 +1176,7 @@ public final class MemoryManager {
   @Interruptible
   public static void addSoftReference(SoftReference<?> obj, Object referent) {
     if (VM.BuildWithRustMMTk) {
-      sysCall.add_soft_candidate(Magic.objectAsAddress(obj),
-              Magic.objectAsAddress(referent));
+      sysCall.sysAddSoftCandidate(obj, ObjectReference.fromObject(referent));
     } else {
       ReferenceProcessor.addSoftCandidate(obj, ObjectReference.fromObject(referent));
     }
@@ -1192,8 +1191,7 @@ public final class MemoryManager {
   @Interruptible
   public static void addWeakReference(WeakReference<?> obj, Object referent) {
     if (VM.BuildWithRustMMTk) {
-      sysCall.add_weak_candidate(Magic.objectAsAddress(obj),
-              Magic.objectAsAddress(referent));
+      sysCall.sysAddWeakCandidate(obj, ObjectReference.fromObject(referent));
     } else {
       ReferenceProcessor.addWeakCandidate(obj, ObjectReference.fromObject(referent));
     }
@@ -1208,8 +1206,7 @@ public final class MemoryManager {
   @Interruptible
   public static void addPhantomReference(PhantomReference<?> obj, Object referent) {
     if (VM.BuildWithRustMMTk) {
-      sysCall.add_phantom_candidate(Magic.objectAsAddress(obj),
-              Magic.objectAsAddress(referent));
+      sysCall.sysAddPhantomCandidate(obj, ObjectReference.fromObject(referent));
     } else {
       ReferenceProcessor.addPhantomCandidate(obj, ObjectReference.fromObject(referent));
     }

--- a/rvm/src/org/jikesrvm/options/OptionSet.java
+++ b/rvm/src/org/jikesrvm/options/OptionSet.java
@@ -84,16 +84,6 @@ public final class OptionSet extends org.vmutil.options.OptionSet {
     byte[] valueBytes = stringToBytes("converting value", value);
 
     if (VM.BuildWithRustMMTk) {
-      if (name.equals("noReferenceTypes")) {
-          Option o = getOption(name);
-          if (o != null) {
-            if (value.equals("true")) {
-              ((BooleanOption) o).setValue(true);
-            } else if (value.equals("false")) {
-              ((BooleanOption) o).setValue(false);
-            }
-          }
-      }
       if (SysCall.sysCall.sysProcess(nameBytes, valueBytes)) {
         return true;
       }

--- a/rvm/src/org/jikesrvm/runtime/BootRecord.java
+++ b/rvm/src/org/jikesrvm/runtime/BootRecord.java
@@ -285,6 +285,7 @@ public class BootRecord {
   public Address add_weak_candidateRIP;
   public Address add_soft_candidateRIP;
   public Address add_phantom_candidateRIP;
+  public Address get_boolean_optionRIP;
   public Address jikesrvm_handle_user_collection_requestRIP;
   public Address harness_beginRIP;
   public Address harness_endRIP;

--- a/rvm/src/org/jikesrvm/runtime/SysCall.java
+++ b/rvm/src/org/jikesrvm/runtime/SysCall.java
@@ -399,6 +399,14 @@ public abstract class SysCall {
   public abstract void add_phantom_candidate(ObjectReference ref, ObjectReference referent);
 
   @Inline
+  public boolean sysGetBooleanOption(byte[] option) {
+    return get_boolean_option(option);
+  }
+  @RustSysCall
+  @SysCallAlignedTemplate
+  public abstract boolean get_boolean_option(byte[] option);
+
+  @Inline
   public void sysAddFinalizer(Object object) {
     add_finalizer(ObjectReference.fromObject(object));
   }

--- a/rvm/src/org/jikesrvm/runtime/SysCall.java
+++ b/rvm/src/org/jikesrvm/runtime/SysCall.java
@@ -371,17 +371,32 @@ public abstract class SysCall {
   @SysCallAlignedTemplate
   public abstract boolean is_mapped_address(Address address);
 
-  @RustSysCall
-  @SysCallAlignedTemplate
-  public abstract void add_weak_candidate(Address ref, Address referent);
+  @Inline
+  public void sysAddWeakCandidate(Object ref, ObjectReference referent) {
+    add_weak_candidate(ObjectReference.fromObject(ref), referent);
+  }
 
   @RustSysCall
   @SysCallAlignedTemplate
-  public abstract void add_soft_candidate(Address ref, Address referent);
+  public abstract void add_weak_candidate(ObjectReference ref, ObjectReference referent);
+
+  @Inline
+  public void sysAddSoftCandidate(Object ref, ObjectReference referent) {
+    add_soft_candidate(ObjectReference.fromObject(ref), referent);
+  }
 
   @RustSysCall
   @SysCallAlignedTemplate
-  public abstract void add_phantom_candidate(Address ref, Address referent);
+  public abstract void add_soft_candidate(ObjectReference ref, ObjectReference referent);
+
+  @Inline
+  public void sysAddPhantomCandidate(Object ref, ObjectReference referent) {
+    add_phantom_candidate(ObjectReference.fromObject(ref), referent);
+  }
+
+  @RustSysCall
+  @SysCallAlignedTemplate
+  public abstract void add_phantom_candidate(ObjectReference ref, ObjectReference referent);
 
   @Inline
   public void sysAddFinalizer(Object object) {

--- a/tools/bootloader/sys.h
+++ b/tools/bootloader/sys.h
@@ -294,6 +294,7 @@ EXTERNAL void* last_heap_address();
 EXTERNAL void add_weak_candidate(void* ref, void* referent);
 EXTERNAL void add_soft_candidate(void* ref, void* referent);
 EXTERNAL void add_phantom_candidate(void* ref, void* referent);
+EXTERNAL bool get_boolean_option(char* option);
 EXTERNAL void harness_begin(void *tls);
 EXTERNAL void harness_end();
 EXTERNAL void release_buffer(void* buffer);


### PR DESCRIPTION
This PR is related with https://github.com/mmtk/mmtk-jikesrvm/pull/109 for weak reference support.
* The JikesRVM Option `NoReferenceTypes` is no longer set to `true` to disable reference types. Instead, when using with Rust MMTk, JikesRVM will query the third party heap to get boolean option for `noReferenceTypes`.
* Properly deal with address vs object vs object reference in the `addXXXXReference()` methods.