### PR TITLE
Support dynamic syscall with 3-6 parameters

### DIFF
--- a/rvm/src/org/jikesrvm/runtime/BootRecord.java
+++ b/rvm/src/org/jikesrvm/runtime/BootRecord.java
@@ -253,6 +253,10 @@ public class BootRecord {
   public Address alignedHandleUserCollectionRequestRIP;
   public Address sysDynamicCall1RIP;
   public Address sysDynamicCall2RIP;
+  public Address sysDynamicCall3RIP;
+  public Address sysDynamicCall4RIP;
+  public Address sysDynamicCall5RIP;
+  public Address sysDynamicCall6RIP;
 
   //mmtk.h - Rust Functions
   public Address release_bufferRIP;

--- a/rvm/src/org/jikesrvm/runtime/SysCall.java
+++ b/rvm/src/org/jikesrvm/runtime/SysCall.java
@@ -174,6 +174,18 @@ public abstract class SysCall {
   @RustSysCall
   @SysCallTemplate
   public abstract Address sysDynamicCall2(Address funcPtr, Word arg0, Word arg1);
+  @RustSysCall
+  @SysCallTemplate
+  public abstract Address sysDynamicCall3(Address funcPtr, Word arg0, Word arg1, Word arg2);
+  @RustSysCall
+  @SysCallTemplate
+  public abstract Address sysDynamicCall4(Address funcPtr, Word arg0, Word arg1, Word arg2, Word arg3);
+  @RustSysCall
+  @SysCallTemplate
+  public abstract Address sysDynamicCall5(Address funcPtr, Word arg0, Word arg1, Word arg2, Word arg3, Word arg4);
+  @RustSysCall
+  @SysCallTemplate
+  public abstract Address sysDynamicCall6(Address funcPtr, Word arg0, Word arg1, Word arg2, Word arg3, Word arg4, Word arg5);
 
   @RustSysCall
   @SysCallAlignedTemplate

--- a/tools/bootloader/sys.h
+++ b/tools/bootloader/sys.h
@@ -246,8 +246,12 @@ EXTERNAL void alignedEnableCollection(size_t thread_id) __attribute__((force_ali
 EXTERNAL bool alignedProcess(char* name, char* value) __attribute__((force_align_arg_pointer));
 EXTERNAL void alignedPostAlloc(void* mutator, void* refer, void* type_refer, int bytes, int allocator) __attribute__((force_align_arg_pointer));
 EXTERNAL void alignedHandleUserCollectionRequest(size_t thread_id) __attribute__((force_align_arg_pointer));
-EXTERNAL void sysDynamicCall1(void* (*func_ptr)(void*), void* arg0) __attribute__((force_align_arg_pointer));
-EXTERNAL void sysDynamicCall2(void* (*func_ptr)(void*, void*), void* arg0, void* arg1) __attribute__((force_align_arg_pointer));
+EXTERNAL void* sysDynamicCall1(void* (*func_ptr)(void*), void* arg0) __attribute__((force_align_arg_pointer));
+EXTERNAL void* sysDynamicCall2(void* (*func_ptr)(void*, void*), void* arg0, void* arg1) __attribute__((force_align_arg_pointer));
+EXTERNAL void* sysDynamicCall3(void* (*func_ptr)(void*, void*, void*), void* arg0, void* arg1, void* arg2) __attribute__((force_align_arg_pointer));
+EXTERNAL void* sysDynamicCall4(void* (*func_ptr)(void*, void*, void*, void*), void* arg0, void* arg1, void* arg2, void* arg3) __attribute__((force_align_arg_pointer));
+EXTERNAL void* sysDynamicCall5(void* (*func_ptr)(void*, void*, void*, void*, void*), void* arg0, void* arg1, void* arg2, void* arg3, void* arg4) __attribute__((force_align_arg_pointer));
+EXTERNAL void* sysDynamicCall6(void* (*func_ptr)(void*, void*, void*, void*, void*, void*), void* arg0, void* arg1, void* arg2, void* arg3, void* arg4, void* arg5) __attribute__((force_align_arg_pointer));
 
 EXTERNAL void* bind_mutator(void *tls);
 EXTERNAL void destroy_mutator(void* mutator);

--- a/tools/bootloader/sysMMTk.c
+++ b/tools/bootloader/sysMMTk.c
@@ -75,11 +75,27 @@ EXTERNAL void* alignedGetFinalizedObject() {
     return get_finalized_object();
 }
 
-EXTERNAL void sysDynamicCall1(void* (*func_ptr)(void*), void* arg0){
+EXTERNAL void* sysDynamicCall1(void* (*func_ptr)(void*), void* arg0) {
     return func_ptr(arg0);
 }
 
-EXTERNAL void sysDynamicCall2(void* (*func_ptr)(void*, void*), void* arg0, void* arg1) {
+EXTERNAL void* sysDynamicCall2(void* (*func_ptr)(void*, void*), void* arg0, void* arg1) {
     return func_ptr(arg0, arg1);
+}
+
+EXTERNAL void* sysDynamicCall3(void* (*func_ptr)(void*, void*, void*), void* arg0, void* arg1, void* arg2) {
+    return func_ptr(arg0, arg1, arg2);
+}
+
+EXTERNAL void* sysDynamicCall4(void* (*func_ptr)(void*, void*, void*, void*), void* arg0, void* arg1, void* arg2, void* arg3) {
+    return func_ptr(arg0, arg1, arg2, arg3);
+}
+
+EXTERNAL void* sysDynamicCall5(void* (*func_ptr)(void*, void*, void*, void*, void*), void* arg0, void* arg1, void* arg2, void* arg3, void* arg4) {
+    return func_ptr(arg0, arg1, arg2, arg3, arg4);
+}
+
+EXTERNAL void* sysDynamicCall6(void* (*func_ptr)(void*, void*, void*, void*, void*, void*), void* arg0, void* arg1, void* arg2, void* arg3, void* arg4, void* arg5) {
+    return func_ptr(arg0, arg1, arg2, arg3, arg4, arg5);
 }
 #endif


### PR DESCRIPTION
This PR add support for `sysDynamicCall` with 3 to 6 parameters.  I am making a change on the stack-scanning API and introduced a call-back function that needs 3 parameters.  I just added support for 4-6 parameters, too, just in case they would be needed in the future.

The existing return type for `sysDynamicCallX` in C is `void`, but I think it should be `void*`.

```diff
-EXTERNAL void sysDynamicCall2(void* (*func_ptr)(void*, void*), void* arg0, void* arg1) {
+EXTERNAL void* sysDynamicCall2(void* (*func_ptr)(void*, void*), void* arg0, void* arg1) {
     return func_ptr(arg0, arg1);
 }
```

The Java signature has `Address` as the return type:
```java
   @RustSysCall
   @SysCallTemplate
   public abstract Address sysDynamicCall2(Address funcPtr, Word arg0, Word arg1);
```

I think it is a bug.  It should return the return value of calling `func_ptr`.  It worked by a accident, because the return value was held in the `EAX` register after calling `func_ptr`, and was preserved when `sysDynamicCall2` returned.  The C compiler is not required to behave like this, but it did that way.