### PR TITLE
Convert boolean option key string to null terminated bytes.

### DIFF
--- a/rvm/src/org/jikesrvm/mm/mminterface/MemoryManager.java
+++ b/rvm/src/org/jikesrvm/mm/mminterface/MemoryManager.java
@@ -75,6 +75,7 @@ import org.vmmagic.unboxed.ObjectReference;
 import org.vmmagic.unboxed.Offset;
 import org.vmmagic.unboxed.Word;
 import org.vmmagic.unboxed.WordArray;
+import org.jikesrvm.util.StringUtilities;
 
 import static org.jikesrvm.runtime.SysCall.sysCall;
 
@@ -220,7 +221,7 @@ public final class MemoryManager {
       VM.sysFail("postBoot() unimplemented");
     } else {
       Selected.Plan.get().processOptions();
-      if (Options.noReferenceTypes.getValue() || (VM.BuildWithRustMMTk && sysCall.sysGetBooleanOption(Options.noReferenceTypes.getKey().getBytes()))) {
+      if (Options.noReferenceTypes.getValue() || (VM.BuildWithRustMMTk && sysCall.sysGetBooleanOption(StringUtilities.stringToBytesNullTerminated(Options.noReferenceTypes.getKey())))) {
         RVMType.JavaLangRefReferenceReferenceField.makeTraced();
       }
 


### PR DESCRIPTION
This PR fixes an issue that when we pass the option key to Rust, the string may not end properly with null terminator.