### PR TITLE
Change the default boot image address for x86_64-m32 to avoid address space conflict

### DIFF
--- a/build/targets/x86_64_m32-linux.properties
+++ b/build/targets/x86_64_m32-linux.properties
@@ -13,10 +13,10 @@
 target.arch=ia32
 target.endianness=little
 target.os=Linux
-target.bootimage.code.address=0x64000000
-target.bootimage.data.address=0x60000000
-target.bootimage.rmap.address=0x67000000
-target.max-mappable.address=0xb0000000
+target.bootimage.code.address=0x74000000
+target.bootimage.data.address=0x70000000
+target.bootimage.rmap.address=0x77000000
+target.max-mappable.address=0xd0000000
 target.address.size=32
 target.dll-ext=.so
 target.dll-prefix=lib


### PR DESCRIPTION
This mitigates the issues in https://github.com/mmtk/mmtk-jikesrvm/issues/168.